### PR TITLE
Removed non Base64 option from protobuf serializer.

### DIFF
--- a/src/Component/Furysoft.Serializers/Base64Helpers.cs
+++ b/src/Component/Furysoft.Serializers/Base64Helpers.cs
@@ -6,12 +6,12 @@
 
 namespace Furysoft.Serializers
 {
+    using System;
     using System.IO;
-    using System.Text;
     using JetBrains.Annotations;
 
     /// <summary>
-    /// The Base 64 Helpers
+    /// The Base 64 Helpers.
     /// </summary>
     public static class Base64Helpers
     {
@@ -19,7 +19,7 @@ namespace Furysoft.Serializers
         /// Decodes the base64 to bytes.
         /// </summary>
         /// <param name="source">The source.</param>
-        /// <returns>The Original <see cref="!:byte[]"/></returns>
+        /// <returns>The Original <see cref="!:byte[]"/>.</returns>
         public static byte[] DecodeBase64ToBytes([NotNull] this string source)
         {
             var base64EncodedBytes = System.Convert.FromBase64String(source);
@@ -30,7 +30,7 @@ namespace Furysoft.Serializers
         /// Decodes the base64 to stream.
         /// </summary>
         /// <param name="source">The source.</param>
-        /// <returns>The <see cref="Stream"/></returns>
+        /// <returns>The <see cref="Stream"/>.</returns>
         public static Stream DecodeBase64ToStream([NotNull] this string source)
         {
             var bytes = source.DecodeBase64ToBytes();
@@ -43,21 +43,23 @@ namespace Furysoft.Serializers
         /// From the base64 string.
         /// </summary>
         /// <param name="source">The source.</param>
-        /// <returns>The Original String</returns>
+        /// <returns>The Original String.</returns>
         public static string DecodeBase64ToString([NotNull] this string source)
         {
             var base64EncodedBytes = System.Convert.FromBase64String(source);
-            return Encoding.GetEncoding("iso-8859-1").GetString(base64EncodedBytes);
+            var s
+                = System.Text.Encoding.UTF8.GetString(base64EncodedBytes, 0, base64EncodedBytes.Length);
+            return s;
         }
 
         /// <summary>
         /// To the base64 string.
         /// </summary>
         /// <param name="source">The source.</param>
-        /// <returns>The base 64 encoded string</returns>
+        /// <returns>The base 64 encoded string.</returns>
         public static string ToBase64String([NotNull] this string source)
         {
-            var bytes = Encoding.GetEncoding("iso-8859-1").GetBytes(source);
+            var bytes = System.Text.Encoding.UTF8.GetBytes(source);
             return System.Convert.ToBase64String(bytes);
         }
 
@@ -65,7 +67,7 @@ namespace Furysoft.Serializers
         /// To the base64 string.
         /// </summary>
         /// <param name="source">The source.</param>
-        /// <returns>The base 64 encoded string</returns>
+        /// <returns>The base 64 encoded string.</returns>
         public static string ToBase64String([NotNull] this byte[] source)
         {
             return System.Convert.ToBase64String(source);
@@ -75,32 +77,20 @@ namespace Furysoft.Serializers
         /// To the base64 string.
         /// </summary>
         /// <param name="source">The source.</param>
-        /// <returns>The base 64 encoded string</returns>
+        /// <returns>The base 64 encoded string.</returns>
         public static string ToBase64String([NotNull] this Stream source)
         {
-            var readFully = ReadFully(source);
+            string rtn;
 
-            return System.Convert.ToBase64String(readFully);
-        }
-
-        /// <summary>
-        /// Reads the fully.
-        /// </summary>
-        /// <param name="input">The input.</param>
-        /// <returns>The <see cref="!:byte[]"/></returns>
-        private static byte[] ReadFully(Stream input)
-        {
-            var buffer = new byte[16 * 1024];
             using (var ms = new MemoryStream())
             {
-                int read;
-                while ((read = input.Read(buffer, 0, buffer.Length)) > 0)
-                {
-                    ms.Write(buffer, 0, read);
-                }
+                source.CopyTo(ms);
+                ms.Position = 0;
 
-                return ms.ToArray();
+                rtn = Convert.ToBase64String(ms.ToArray());
             }
+
+            return rtn;
         }
     }
 }

--- a/src/Component/Furysoft.Serializers/Entities/SerializerType.cs
+++ b/src/Component/Furysoft.Serializers/Entities/SerializerType.cs
@@ -7,7 +7,7 @@
 namespace Furysoft.Serializers.Entities
 {
     /// <summary>
-    /// The Serializer Type
+    /// The Serializer Type.
     /// </summary>
     public enum SerializerType
     {
@@ -29,6 +29,6 @@ namespace Furysoft.Serializers.Entities
         /// <summary>
         /// The protocol buffers
         /// </summary>
-        ProtocolBuffers = 3
+        ProtocolBuffers = 3,
     }
 }

--- a/src/Component/Furysoft.Serializers/Furysoft.Serializers.csproj
+++ b/src/Component/Furysoft.Serializers/Furysoft.Serializers.csproj
@@ -9,11 +9,11 @@
     <RepositoryUrl>https://github.com/Furysoft/Serializers</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>Furysoft Serializers</PackageTags>
-    <PackageReleaseNotes>Initial Release</PackageReleaseNotes>
+    <PackageReleaseNotes>Removed non Base64 option from protobuf serializer.</PackageReleaseNotes>
     <Authors>Simon Paramore</Authors>
     <Company>Furysoft</Company>
     <Description>Serializer helper methods for XML, JSON, and Protobuf</Description>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
   </PropertyGroup>
 
   <ItemGroup>
@@ -23,11 +23,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Jetbrains.Annotations" Version="11.1.0" PrivateAssets="All" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="protobuf-net" Version="2.3.13" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.0.2" PrivateAssets="All" />
-    <PackageReference Include="System.Runtime" Version="4.3.0" />
+    <PackageReference Include="Jetbrains.Annotations" Version="2020.1.0" PrivateAssets="All" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="protobuf-net" Version="3.0.29" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="System.Runtime" Version="4.3.1" />
     <PackageReference Include="System.Runtime.Serialization.Xml" Version="4.3.0" />
   </ItemGroup>
 

--- a/src/Component/Furysoft.Serializers/ISerializer.cs
+++ b/src/Component/Furysoft.Serializers/ISerializer.cs
@@ -10,7 +10,7 @@ namespace Furysoft.Serializers
     using System.IO;
 
     /// <summary>
-    /// The Serializer Interface
+    /// The Serializer Interface.
     /// </summary>
     public interface ISerializer
     {
@@ -19,7 +19,7 @@ namespace Furysoft.Serializers
         /// </summary>
         /// <typeparam name="TType">The type of the type.</typeparam>
         /// <param name="data">The data.</param>
-        /// <returns>The TType</returns>
+        /// <returns>The TType.</returns>
         TType DeserializeFromByteArray<TType>(byte[] data);
 
         /// <summary>
@@ -27,7 +27,7 @@ namespace Furysoft.Serializers
         /// </summary>
         /// <param name="data">The data.</param>
         /// <param name="type">The type.</param>
-        /// <returns>The Deserialized Object</returns>
+        /// <returns>The Deserialized Object.</returns>
         object DeserializeFromByteArray(byte[] data, Type type);
 
         /// <summary>
@@ -35,7 +35,7 @@ namespace Furysoft.Serializers
         /// </summary>
         /// <typeparam name="TType">The type of the type.</typeparam>
         /// <param name="data">The data.</param>
-        /// <returns>The TType</returns>
+        /// <returns>The TType.</returns>
         TType DeserializeFromStream<TType>(Stream data);
 
         /// <summary>
@@ -43,7 +43,7 @@ namespace Furysoft.Serializers
         /// </summary>
         /// <param name="data">The data.</param>
         /// <param name="type">The type.</param>
-        /// <returns>The Deserialized Object</returns>
+        /// <returns>The Deserialized Object.</returns>
         object DeserializeFromStream(Stream data, Type type);
 
         /// <summary>
@@ -51,7 +51,7 @@ namespace Furysoft.Serializers
         /// </summary>
         /// <typeparam name="TType">The type of the type.</typeparam>
         /// <param name="data">The data.</param>
-        /// <returns>The TType</returns>
+        /// <returns>The TType.</returns>
         TType DeserializeFromString<TType>(string data);
 
         /// <summary>
@@ -59,7 +59,7 @@ namespace Furysoft.Serializers
         /// </summary>
         /// <param name="data">The data.</param>
         /// <param name="type">The type.</param>
-        /// <returns>The Deserialized Object</returns>
+        /// <returns>The Deserialized Object.</returns>
         object DeserializeFromString(string data, Type type);
 
         /// <summary>
@@ -68,7 +68,7 @@ namespace Furysoft.Serializers
         /// <typeparam name="TType">The type of the type.</typeparam>
         /// <param name="content">The content.</param>
         /// <returns>
-        /// The Serialized Data
+        /// The Serialized Data.
         /// </returns>
         byte[] SerializeToByteArray<TType>(TType content);
 
@@ -78,7 +78,7 @@ namespace Furysoft.Serializers
         /// <param name="content">The content.</param>
         /// <param name="type">The type.</param>
         /// <returns>
-        /// The Serialized Data
+        /// The Serialized Data.
         /// </returns>
         byte[] SerializeToByteArray(object content, Type type);
 
@@ -87,7 +87,7 @@ namespace Furysoft.Serializers
         /// </summary>
         /// <typeparam name="TType">The type of the type.</typeparam>
         /// <param name="content">The content.</param>
-        /// <returns>The <see cref="Stream"/></returns>
+        /// <returns>The <see cref="Stream"/>.</returns>
         Stream SerializeToStream<TType>(TType content);
 
         /// <summary>
@@ -96,7 +96,7 @@ namespace Furysoft.Serializers
         /// <param name="content">The content.</param>
         /// <param name="type">The type.</param>
         /// <returns>
-        /// The Serialized Data
+        /// The Serialized Data.
         /// </returns>
         Stream SerializeToStream(object content, Type type);
 
@@ -106,7 +106,7 @@ namespace Furysoft.Serializers
         /// <typeparam name="TType">The type of the type.</typeparam>
         /// <param name="content">The content.</param>
         /// <returns>
-        /// The Serialized Data
+        /// The Serialized Data.
         /// </returns>
         string SerializeToString<TType>(TType content);
 
@@ -116,7 +116,7 @@ namespace Furysoft.Serializers
         /// <param name="content">The content.</param>
         /// <param name="type">The type.</param>
         /// <returns>
-        /// The Serialized Data
+        /// The Serialized Data.
         /// </returns>
         string SerializeToString(object content, Type type);
     }

--- a/src/Component/Furysoft.Serializers/InternalsVisibleTo.cs
+++ b/src/Component/Furysoft.Serializers/InternalsVisibleTo.cs
@@ -1,9 +1,0 @@
-﻿// --------------------------------------------------------------------------------------------------------------------
-// <copyright file="InternalsVisibleTo.cs" company="Simon Paramore">
-// © 2017, Simon Paramore
-// </copyright>
-// --------------------------------------------------------------------------------------------------------------------
-
-using System.Runtime.CompilerServices;
-
-[assembly: InternalsVisibleTo("Furysoft.Serializers.Tests")]

--- a/src/Component/Furysoft.Serializers/Logic/JsonSerializer.cs
+++ b/src/Component/Furysoft.Serializers/Logic/JsonSerializer.cs
@@ -12,12 +12,12 @@ namespace Furysoft.Serializers.Logic
     using Newtonsoft.Json;
 
     /// <summary>
-    /// The JSON Serializer
+    /// The JSON Serializer.
     /// </summary>
     public sealed class JsonSerializer : ISerializer
     {
         /// <summary>
-        /// The encode as base64
+        /// The encode as base64.
         /// </summary>
         private readonly bool encodeAsBase64;
 

--- a/src/Component/Furysoft.Serializers/Logic/XmlSerializer.cs
+++ b/src/Component/Furysoft.Serializers/Logic/XmlSerializer.cs
@@ -11,13 +11,13 @@ namespace Furysoft.Serializers.Logic
     using System.Runtime.Serialization;
 
     /// <summary>
-    /// The XML Serializer
+    /// The XML Serializer.
     /// </summary>
     /// <seealso cref="Furysoft.Serializers.ISerializer" />
     public sealed class XmlSerializer : ISerializer
     {
         /// <summary>
-        /// The encode as base64
+        /// The encode as base64.
         /// </summary>
         private readonly bool encodeAsBase64;
 
@@ -36,7 +36,7 @@ namespace Furysoft.Serializers.Logic
         /// <typeparam name="TType">The type of the type.</typeparam>
         /// <param name="data">The data.</param>
         /// <returns>
-        /// The TType
+        /// The TType.
         /// </returns>
         public TType DeserializeFromByteArray<TType>(byte[] data)
         {
@@ -189,7 +189,7 @@ namespace Furysoft.Serializers.Logic
         /// Gets as stream.
         /// </summary>
         /// <param name="data">The data.</param>
-        /// <returns>The <see cref="Stream"/></returns>
+        /// <returns>The <see cref="Stream"/>.</returns>
         private static Stream GetAsStream(string data)
         {
             var stream = new MemoryStream();
@@ -204,7 +204,7 @@ namespace Furysoft.Serializers.Logic
         /// Gets as stream.
         /// </summary>
         /// <param name="data">The data.</param>
-        /// <returns>The <see cref="Stream"/></returns>
+        /// <returns>The <see cref="Stream"/>.</returns>
         private static Stream GetAsStream(byte[] data)
         {
             var ms = new MemoryStream();

--- a/src/Component/Furysoft.Serializers/Properties/AssemblyInfo.cs
+++ b/src/Component/Furysoft.Serializers/Properties/AssemblyInfo.cs
@@ -1,0 +1,7 @@
+// <copyright file="AssemblyInfo.cs" company="Simon Paramore">
+// © 2017, Simon Paramore
+// </copyright>
+
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Furysoft.Serializers.Tests")]

--- a/src/Component/Furysoft.Serializers/SerializerFactory.cs
+++ b/src/Component/Furysoft.Serializers/SerializerFactory.cs
@@ -7,11 +7,11 @@
 namespace Furysoft.Serializers
 {
     using System;
-    using Entities;
-    using Logic;
+    using Furysoft.Serializers.Entities;
+    using Furysoft.Serializers.Logic;
 
     /// <summary>
-    /// The Serializer Factory
+    /// The Serializer Factory.
     /// </summary>
     public static class SerializerFactory
     {
@@ -21,10 +21,10 @@ namespace Furysoft.Serializers
         /// <param name="type">The type.</param>
         /// <param name="base64Encode">if set to <c>true</c> [base64 encode].</param>
         /// <returns>
-        /// The <see cref="ISerializer" />
+        /// The <see cref="ISerializer" />.
         /// </returns>
-        /// <exception cref="System.ArgumentOutOfRangeException">type - null</exception>
-        /// <exception cref="ArgumentOutOfRangeException">type is invalid</exception>
+        /// <exception cref="System.ArgumentOutOfRangeException">type - null.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">type is invalid.</exception>
         public static ISerializer Create(SerializerType type, bool base64Encode = false)
         {
             switch (type)
@@ -36,7 +36,7 @@ namespace Furysoft.Serializers
                     return new JsonSerializer(base64Encode);
 
                 case SerializerType.ProtocolBuffers:
-                    return new ProtocolBufferSerializer(base64Encode);
+                    return new ProtocolBufferSerializer();
 
                 case SerializerType.None:
                 default:

--- a/src/Component/Furysoft.Serializers/SerializerHelpers.cs
+++ b/src/Component/Furysoft.Serializers/SerializerHelpers.cs
@@ -8,10 +8,10 @@ namespace Furysoft.Serializers
 {
     using System;
     using System.IO;
-    using Entities;
+    using Furysoft.Serializers.Entities;
 
     /// <summary>
-    /// The Serializer Helpers
+    /// The Serializer Helpers.
     /// </summary>
     public static class SerializerHelpers
     {
@@ -22,7 +22,7 @@ namespace Furysoft.Serializers
         /// <param name="serializedData">The serialized data.</param>
         /// <param name="serializerType">Type of the serializer.</param>
         /// <returns>
-        /// The TEntity
+        /// The TEntity.
         /// </returns>
         public static TEntity Deserialize<TEntity>(
             this Stream serializedData,
@@ -40,7 +40,7 @@ namespace Furysoft.Serializers
         /// <param name="serializedData">The serialized data.</param>
         /// <param name="type">The type.</param>
         /// <param name="serializerType">Type of the serializer.</param>
-        /// <returns>The Deserialized Object</returns>
+        /// <returns>The Deserialized Object.</returns>
         public static object Deserialize(
             this Stream serializedData,
             Type type,
@@ -58,7 +58,7 @@ namespace Furysoft.Serializers
         /// <param name="serializedData">The serialized data.</param>
         /// <param name="serializerType">Type of the serializer.</param>
         /// <returns>
-        /// The TEntity
+        /// The TEntity.
         /// </returns>
         public static TEntity Deserialize<TEntity>(
             this string serializedData,
@@ -76,7 +76,7 @@ namespace Furysoft.Serializers
         /// <param name="serializedData">The serialized data.</param>
         /// <param name="type">The type.</param>
         /// <param name="serializerType">Type of the serializer.</param>
-        /// <returns>The Deserialized Object</returns>
+        /// <returns>The Deserialized Object.</returns>
         public static object Deserialize(
             this string serializedData,
             Type type,
@@ -94,7 +94,7 @@ namespace Furysoft.Serializers
         /// <param name="serializedData">The serialized data.</param>
         /// <param name="serializerType">Type of the serializer.</param>
         /// <returns>
-        /// The TEntity
+        /// The TEntity.
         /// </returns>
         public static TEntity Deserialize<TEntity>(
             this byte[] serializedData,
@@ -112,7 +112,7 @@ namespace Furysoft.Serializers
         /// <param name="serializedData">The serialized data.</param>
         /// <param name="type">The type.</param>
         /// <param name="serializerType">Type of the serializer.</param>
-        /// <returns>The Deserialized Object</returns>
+        /// <returns>The Deserialized Object.</returns>
         public static object Deserialize(
             this byte[] serializedData,
             Type type,
@@ -130,7 +130,7 @@ namespace Furysoft.Serializers
         /// <param name="data">The data.</param>
         /// <param name="serializerType">Type of the serializer.</param>
         /// <returns>
-        /// The <see cref="byte" />
+        /// The <see cref="byte" />.
         /// </returns>
         public static byte[] SerializeToByteArray<TEntity>(
             this TEntity data,
@@ -149,7 +149,7 @@ namespace Furysoft.Serializers
         /// <param name="type">The type.</param>
         /// <param name="serializerType">Type of the serializer.</param>
         /// <returns>
-        /// The <see cref="byte" />
+        /// The <see cref="byte" />.
         /// </returns>
         public static byte[] SerializeToByteArray(
             this object data,
@@ -168,7 +168,7 @@ namespace Furysoft.Serializers
         /// <param name="data">The data.</param>
         /// <param name="serializerType">Type of the serializer.</param>
         /// <returns>
-        /// The <see cref="Stream" />
+        /// The <see cref="Stream" />.
         /// </returns>
         public static Stream SerializeToStream<TEntity>(
             this TEntity data,
@@ -186,7 +186,7 @@ namespace Furysoft.Serializers
         /// <param name="data">The data.</param>
         /// <param name="type">The type.</param>
         /// <param name="serializerType">Type of the serializer.</param>
-        /// <returns>The <see cref="Stream"/></returns>
+        /// <returns>The <see cref="Stream"/>.</returns>
         public static Stream SerializeToStream(
             this object data,
             Type type,
@@ -204,7 +204,7 @@ namespace Furysoft.Serializers
         /// <param name="data">The data.</param>
         /// <param name="serializerType">Type of the serializer.</param>
         /// <returns>
-        /// The serialized string
+        /// The serialized string.
         /// </returns>
         public static string SerializeToString<TEntity>(
             this TEntity data,
@@ -223,7 +223,7 @@ namespace Furysoft.Serializers
         /// <param name="type">The type.</param>
         /// <param name="serializerType">Type of the serializer.</param>
         /// <returns>
-        /// The serialized string
+        /// The serialized string.
         /// </returns>
         public static string SerializeToString(
             this object data,

--- a/src/Furysoft.Serializers.sln
+++ b/src/Furysoft.Serializers.sln
@@ -36,6 +36,7 @@ Global
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{3FD3F57C-A5CF-402D-B3B0-5ACC95A060BF} = {59CB03F3-5611-448F-9D50-2423676A7A06}
+		{C265550C-01D4-4936-8BCD-809F1EC502B9} = {CB15B5AD-EF52-4D54-8F92-03DC0E3EE86D}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {0876DC42-8E5E-40E9-8485-D976A22DEF45}

--- a/src/Tests/Furysoft.Serializers.Tests/Furysoft.Serializers.Tests.csproj
+++ b/src/Tests/Furysoft.Serializers.Tests/Furysoft.Serializers.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -14,14 +14,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
-    <PackageReference Include="newtonsoft.json" Version="11.0.2" />
-    <PackageReference Include="nunit" Version="3.10.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
-    <PackageReference Include="protobuf-net" Version="2.3.13" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="2.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+    <PackageReference Include="newtonsoft.json" Version="12.0.3" />
+    <PackageReference Include="nunit" Version="3.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+    <PackageReference Include="protobuf-net" Version="3.0.29" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
-    <PackageReference Include="Stylecop.Analyzers" Version="1.0.2" PrivateAssets="All" />
+    <PackageReference Include="Stylecop.Analyzers" Version="1.1.118" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Tests/Furysoft.Serializers.Tests/Helpers/TestHelper.cs
+++ b/src/Tests/Furysoft.Serializers.Tests/Helpers/TestHelper.cs
@@ -9,18 +9,18 @@ namespace Furysoft.Serializers.Tests.Helpers
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using Furysoft.Serializers.Tests.TestEntities;
     using NUnit.Framework;
-    using TestEntities;
 
     /// <summary>
-    /// The Test Helper
+    /// The Test Helper.
     /// </summary>
     public static class TestHelper
     {
         /// <summary>
         /// Gets the default test entity.
         /// </summary>
-        /// <returns>The <see cref="TestEntity"/></returns>
+        /// <returns>The <see cref="TestEntity"/>.</returns>
         public static TestEntity GetDefaultTestEntity => new TestEntity
         {
             SomeDictionary = new Dictionary<string, int>
@@ -33,7 +33,7 @@ namespace Furysoft.Serializers.Tests.Helpers
             SomeEntity = new TestEntity { SomeString = "SubString", SomeInt = 2 },
             SomeInt = 1,
             SomeString = "String",
-            SomeDateTime = new DateTime(2018, 1, 1, 5, 23, 59)
+            SomeDateTime = new DateTime(2018, 1, 1, 5, 23, 59),
         };
 
         /// <summary>

--- a/src/Tests/Furysoft.Serializers.Tests/Serializers/Base64SerializerTests.cs
+++ b/src/Tests/Furysoft.Serializers.Tests/Serializers/Base64SerializerTests.cs
@@ -8,13 +8,13 @@ namespace Furysoft.Serializers.Tests.Serializers
 {
     using System;
     using System.Diagnostics;
-    using Helpers;
-    using Logic;
+    using Furysoft.Serializers.Logic;
+    using Furysoft.Serializers.Tests.Helpers;
+    using Furysoft.Serializers.Tests.TestEntities;
     using NUnit.Framework;
-    using TestEntities;
 
     /// <summary>
-    /// The Base 64 Serializer Tests
+    /// The Base 64 Serializer Tests.
     /// </summary>
     /// <seealso cref="TestBase" />
     [TestFixture]
@@ -27,7 +27,7 @@ namespace Furysoft.Serializers.Tests.Serializers
         public void ToBase64String_WhenUsingByteArray_ExpectDeserializeCorrect()
         {
             // Arrange
-            var protocolBufferSerializer = new ProtocolBufferSerializer(false);
+            var protocolBufferSerializer = new ProtocolBufferSerializer();
 
             var testEntity = TestHelper.GetDefaultTestEntity;
 
@@ -57,7 +57,7 @@ namespace Furysoft.Serializers.Tests.Serializers
         public void ToBase64String_WhenUsingStream_ExpectDeserializeCorrect()
         {
             // Arrange
-            var protocolBufferSerializer = new ProtocolBufferSerializer(false);
+            var protocolBufferSerializer = new ProtocolBufferSerializer();
 
             var testEntity = TestHelper.GetDefaultTestEntity;
 
@@ -87,7 +87,7 @@ namespace Furysoft.Serializers.Tests.Serializers
         public void ToBase64String_WhenUsingString_ExpectDeserializeCorrect()
         {
             // Arrange
-            var protocolBufferSerializer = new ProtocolBufferSerializer(false);
+            var protocolBufferSerializer = new ProtocolBufferSerializer();
 
             var testEntity = TestHelper.GetDefaultTestEntity;
 

--- a/src/Tests/Furysoft.Serializers.Tests/Serializers/JsonSerializerTests.cs
+++ b/src/Tests/Furysoft.Serializers.Tests/Serializers/JsonSerializerTests.cs
@@ -8,13 +8,13 @@ namespace Furysoft.Serializers.Tests.Serializers
 {
     using System;
     using System.Diagnostics;
-    using Helpers;
+    using Furysoft.Serializers.Tests.Helpers;
+    using Furysoft.Serializers.Tests.TestEntities;
     using Newtonsoft.Json;
     using NUnit.Framework;
-    using TestEntities;
 
     /// <summary>
-    /// The JSON Serializer Tests
+    /// The JSON Serializer Tests.
     /// </summary>
     /// <seealso cref="TestBase" />
     [TestFixture]

--- a/src/Tests/Furysoft.Serializers.Tests/Serializers/PerformanceTests.cs
+++ b/src/Tests/Furysoft.Serializers.Tests/Serializers/PerformanceTests.cs
@@ -10,14 +10,14 @@ namespace Furysoft.Serializers.Tests.Serializers
     using System.Collections.Generic;
     using System.Diagnostics;
     using System.IO;
-    using Helpers;
-    using Logic;
+    using Furysoft.Serializers.Logic;
+    using Furysoft.Serializers.Tests.Helpers;
+    using Furysoft.Serializers.Tests.TestEntities;
     using NUnit.Framework;
-    using TestEntities;
-    using XmlSerializer = Logic.XmlSerializer;
+    using XmlSerializer = Furysoft.Serializers.Logic.XmlSerializer;
 
     /// <summary>
-    /// The Performance Tests
+    /// The Performance Tests.
     /// </summary>
     [TestFixture]
 #if !DEBUG
@@ -387,7 +387,7 @@ namespace Furysoft.Serializers.Tests.Serializers
 
             Console.WriteLine("Protocol Buffers Tests\r\n******");
 
-            var protocolBufferSerializer = new ProtocolBufferSerializer(false);
+            var protocolBufferSerializer = new ProtocolBufferSerializer();
 
             /* Serialize Tests */
             Console.WriteLine("SerializeToStream");
@@ -473,7 +473,7 @@ namespace Furysoft.Serializers.Tests.Serializers
 
             Console.WriteLine("Protocol Buffers Tests\r\n******");
 
-            var protocolBufferSerializer = new ProtocolBufferSerializer(false);
+            var protocolBufferSerializer = new ProtocolBufferSerializer();
 
             /* Serialize Tests */
             Console.WriteLine("SerializeToStream");
@@ -560,7 +560,7 @@ namespace Furysoft.Serializers.Tests.Serializers
 
             Console.WriteLine("Protocol Buffers Tests\r\n******");
 
-            var protocolBufferSerializer = new ProtocolBufferSerializer(false);
+            var protocolBufferSerializer = new ProtocolBufferSerializer();
 
             /* Serialize Tests */
             Console.WriteLine("SerializeToStream");

--- a/src/Tests/Furysoft.Serializers.Tests/Serializers/ProtocolBufferSerializerTests.cs
+++ b/src/Tests/Furysoft.Serializers.Tests/Serializers/ProtocolBufferSerializerTests.cs
@@ -7,17 +7,15 @@
 namespace Furysoft.Serializers.Tests.Serializers
 {
     using System;
-    using System.Collections.Generic;
     using System.Diagnostics;
-    using Helpers;
-    using Logic;
+    using Furysoft.Serializers.Logic;
+    using Furysoft.Serializers.Tests.Helpers;
+    using Furysoft.Serializers.Tests.TestEntities;
     using Newtonsoft.Json;
     using NUnit.Framework;
-    using ProtoBuf;
-    using TestEntities;
 
     /// <summary>
-    /// The Protocol Buffer Serializer Tests
+    /// The Protocol Buffer Serializer Tests.
     /// </summary>
     [TestFixture]
     public sealed class ProtocolBufferSerializerTests : TestBase
@@ -29,7 +27,7 @@ namespace Furysoft.Serializers.Tests.Serializers
         public void SerializeToByteArray_WhenUsingByteArray_ExpectDeserializeCorrect()
         {
             // Arrange
-            var protocolBufferSerializer = new ProtocolBufferSerializer(false);
+            var protocolBufferSerializer = new ProtocolBufferSerializer();
 
             var testEntity = TestHelper.GetDefaultTestEntity;
 
@@ -56,7 +54,7 @@ namespace Furysoft.Serializers.Tests.Serializers
         public void SerializeToByteArray_WhenUsingByteArrayWithType_ExpectDeserializeCorrect()
         {
             // Arrange
-            var protocolBufferSerializer = new ProtocolBufferSerializer(false);
+            var protocolBufferSerializer = new ProtocolBufferSerializer();
 
             var testEntity = TestHelper.GetDefaultTestEntity;
 
@@ -83,7 +81,7 @@ namespace Furysoft.Serializers.Tests.Serializers
         public void SerializeToStream_WhenUsingStream_ExpectDeserializeCorrect()
         {
             // Arrange
-            var protocolBufferSerializer = new ProtocolBufferSerializer(false);
+            var protocolBufferSerializer = new ProtocolBufferSerializer();
 
             var testEntity = TestHelper.GetDefaultTestEntity;
 
@@ -110,7 +108,7 @@ namespace Furysoft.Serializers.Tests.Serializers
         public void SerializeToStream_WhenUsingStreamWithType_ExpectDeserializeCorrect()
         {
             // Arrange
-            var protocolBufferSerializer = new ProtocolBufferSerializer(false);
+            var protocolBufferSerializer = new ProtocolBufferSerializer();
 
             var testEntity = TestHelper.GetDefaultTestEntity;
 
@@ -137,17 +135,17 @@ namespace Furysoft.Serializers.Tests.Serializers
         public void SerializeToString_WhenDateTime_ExpectSerializeAndDeserialize()
         {
             // Arrange
-            var protocolBufferSerializer = new ProtocolBufferSerializer(false);
+            var protocolBufferSerializer = new ProtocolBufferSerializer();
 
             var testEntity = new TestEntity2
             {
                 Value1 = new DateTime(2018, 1, 1),
-                Value2 = 2.53m
+                Value2 = 2.53m,
             };
 
             // Act
             var stopwatch = Stopwatch.StartNew();
-            var serializeToString = protocolBufferSerializer.SerializeToString(testEntity, typeof(TestEntity));
+            var serializeToString = protocolBufferSerializer.SerializeToString(testEntity, typeof(TestEntity2));
 
             var deserializeFromByteArray = protocolBufferSerializer.DeserializeFromString<TestEntity2>(serializeToString);
 
@@ -167,7 +165,7 @@ namespace Furysoft.Serializers.Tests.Serializers
         public void SerializeToString_WhenUsingString_ExpectDeserializeCorrect()
         {
             // Arrange
-            var protocolBufferSerializer = new ProtocolBufferSerializer(false);
+            var protocolBufferSerializer = new ProtocolBufferSerializer();
 
             var testEntity = TestHelper.GetDefaultTestEntity;
 
@@ -194,7 +192,7 @@ namespace Furysoft.Serializers.Tests.Serializers
         public void SerializeToString_WhenUsingStringWithType_ExpectDeserializeCorrect()
         {
             // Arrange
-            var protocolBufferSerializer = new ProtocolBufferSerializer(false);
+            var protocolBufferSerializer = new ProtocolBufferSerializer();
 
             var testEntity = TestHelper.GetDefaultTestEntity;
 
@@ -213,24 +211,5 @@ namespace Furysoft.Serializers.Tests.Serializers
 
             deserializeFromByteArray.AssertEqualsDefault();
         }
-    }
-
-    /// <summary>
-    /// The Test Entity One
-    /// </summary>
-    [ProtoContract]
-    public sealed class TestEntityOne
-    {
-        /// <summary>
-        /// Gets or sets the int list.
-        /// </summary>
-        [ProtoMember(2)]
-        public List<int> IntList { get; set; }
-
-        /// <summary>
-        /// Gets or sets the string value.
-        /// </summary>
-        [ProtoMember(1)]
-        public string StringValue { get; set; }
     }
 }

--- a/src/Tests/Furysoft.Serializers.Tests/Serializers/XmlSerializerTests.cs
+++ b/src/Tests/Furysoft.Serializers.Tests/Serializers/XmlSerializerTests.cs
@@ -8,14 +8,14 @@ namespace Furysoft.Serializers.Tests.Serializers
 {
     using System;
     using System.Diagnostics;
-    using Helpers;
-    using Logic;
+    using Furysoft.Serializers.Logic;
+    using Furysoft.Serializers.Tests.Helpers;
+    using Furysoft.Serializers.Tests.TestEntities;
     using Newtonsoft.Json;
     using NUnit.Framework;
-    using TestEntities;
 
     /// <summary>
-    /// The XML Serializer Tests
+    /// The XML Serializer Tests.
     /// </summary>
     /// <seealso cref="TestBase" />
     [TestFixture]

--- a/src/Tests/Furysoft.Serializers.Tests/TestBase.cs
+++ b/src/Tests/Furysoft.Serializers.Tests/TestBase.cs
@@ -10,7 +10,7 @@ namespace Furysoft.Serializers.Tests
     using System.Diagnostics;
 
     /// <summary>
-    /// The Test Base
+    /// The Test Base.
     /// </summary>
     public abstract class TestBase
     {

--- a/src/Tests/Furysoft.Serializers.Tests/TestEntities/TestEntity.cs
+++ b/src/Tests/Furysoft.Serializers.Tests/TestEntities/TestEntity.cs
@@ -12,7 +12,7 @@ namespace Furysoft.Serializers.Tests.TestEntities
     using ProtoBuf;
 
     /// <summary>
-    /// The Test Entity
+    /// The Test Entity.
     /// </summary>
     [DataContract]
     [Serializable]

--- a/src/Tests/Furysoft.Serializers.Tests/TestEntities/TestEntity1.cs
+++ b/src/Tests/Furysoft.Serializers.Tests/TestEntities/TestEntity1.cs
@@ -7,23 +7,27 @@
 namespace Furysoft.Serializers.Tests.TestEntities
 {
     using System.Runtime.Serialization;
+    using ProtoBuf;
 
     /// <summary>
-    /// The Test Entity 1
+    /// The Test Entity 1.
     /// </summary>
     [DataContract]
+    [ProtoContract]
     public sealed class TestEntity1
     {
         /// <summary>
         /// Gets or sets the value1.
         /// </summary>
         [DataMember(Order = 1)]
+        [ProtoMember(1)]
         public string Value1 { get; set; }
 
         /// <summary>
         /// Gets or sets the value2.
         /// </summary>
         [DataMember(Order = 2)]
+        [ProtoMember(2)]
         public int Value2 { get; set; }
     }
 }

--- a/src/Tests/Furysoft.Serializers.Tests/TestEntities/TestEntity2.cs
+++ b/src/Tests/Furysoft.Serializers.Tests/TestEntities/TestEntity2.cs
@@ -8,23 +8,27 @@ namespace Furysoft.Serializers.Tests.TestEntities
 {
     using System;
     using System.Runtime.Serialization;
+    using ProtoBuf;
 
     /// <summary>
-    /// The Test Entity 2
+    /// The Test Entity 2.
     /// </summary>
     [DataContract]
+    [ProtoContract]
     public sealed class TestEntity2
     {
         /// <summary>
         /// Gets or sets the value1.
         /// </summary>
         [DataMember(Order = 1)]
+        [ProtoMember(1)]
         public DateTime Value1 { get; set; }
 
         /// <summary>
         /// Gets or sets the value2.
         /// </summary>
         [DataMember(Order = 2)]
+        [ProtoMember(2)]
         public decimal Value2 { get; set; }
     }
 }


### PR DESCRIPTION
Hey Si.

Getting big challenges here when trying to update to new [Queue storage libraries](https://www.nuget.org/packages/Azure.Storage.Queues).

The problem is that the new queue libraries expect base64 strings to be through queues and therefore don't work (exception thrown) when trying to pass a plain "string" representation of a Protobuf object.

I'm guessing that the non-base64 option was causing you some pain originally too because of the proprietary iso-8859-1 encoding being used to serialize and deserialize strings?

I've therefore removed the option for non-base64 strings as far as protobuf is concerned.

When you get a minute, can you take a look at this PR please?

For now, we've had to keep running with the old [MS Queue storage libraries](https://www.nuget.org/packages/Microsoft.Azure.Storage.Queue/).

On changing this up, there will be a major impact on HippoWorld etc....

TY.

Regards,


Rowland

